### PR TITLE
Add link for password rotation implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # iron-go [![Build Status](https://travis-ci.org/WatchBeam/iron-go.svg?branch=master)](https://travis-ci.org/WatchBeam/iron-go) [![godoc reference](https://godoc.org/github.com/WatchBeam/iron-go?status.png)](https://godoc.org/github.com/WatchBeam/iron-go)
 
 
-iron-go is an implementation of [Iron](https://github.com/hueniverse/iron) cookies for Go. It's fully inter-operable with the Node version. Currently it supports sealing and unsealing using a single secret key, but it should be fairly trivial to implement rotation in the future. <sup>[Citation Needed]</sup>
+iron-go is an implementation of [Iron](https://github.com/hueniverse/iron) cookies for Go. It's fully inter-operable with the Node version. Currently it supports sealing and unsealing using a single secret key, but it should be fairly trivial to implement rotation in the future [Commit which add password rotation support to Iron](https://github.com/hueniverse/iron/commit/b96cb22aee74d3871a89cd52f5ea1dd221b735bc).
 
 
 ```go


### PR DESCRIPTION
Include an URL which shows that adding password rotation is fairly easy to the 'readme.md' file. 

