### PR TITLE
chore: updating travis and godoc URLs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# iron-go [![Build Status](https://travis-ci.org/WatchBeam/iron-go.svg?branch=master)](https://travis-ci.org/WatchBeam/iron-go) [![godoc reference](https://godoc.org/github.com/WatchBeam/iron-go?status.png)](https://godoc.org/github.com/WatchBeam/iron-go)
+# iron-go [![Build Status](https://travis-ci.org/mixer/iron-go.svg?branch=master)](https://travis-ci.org/mixer/iron-go) [![godoc reference](https://godoc.org/github.com/mixer/iron-go?status.png)](https://godoc.org/github.com/mixer/iron-go)
 
 
 iron-go is an implementation of [Iron](https://github.com/hueniverse/iron) cookies for Go. It's fully inter-operable with the Node version. Currently it supports sealing and unsealing using a single secret key, but it should be fairly trivial to implement rotation in the future. <sup>[Citation Needed]</sup>


### PR DESCRIPTION
chore: updating travis and godoc

URLs were using 'WatchBeam', not using 'mixer'